### PR TITLE
Add Org-Wide Contribution & Code-Of-Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # GTNH Code of Conduct
 
-## Scope
-
 This Code of Conduct applies to anyone representing or contributing to the GTNH project, including on GitHub, Discord, and any other GTNH-related space.
+
+---
 
 ## Expected Behavior
 
@@ -21,6 +21,8 @@ This includes, but is not limited to:
 
 Behind every pull request, issue, or review comment is a person who has invested time and effort into the project. A single rude or dismissive comment can discourage someone from contributing again. Today’s new contributor may become tomorrow’s project lead.
 
+---
+
 ## Unacceptable Behavior
 
 The following behavior is not acceptable:
@@ -33,6 +35,8 @@ The following behavior is not acceptable:
 - Representing GTNH in a way that damages the project or discourages contribution.
 
 Disagreement is allowed. Strong technical opinions are allowed. Personal attacks are not.
+
+---
 
 ## Review Conduct
 
@@ -48,11 +52,15 @@ Good review behavior includes:
 
 If a pull request is unclear, incomplete, or incorrect, say so respectfully and explain what is needed.
 
+---
+
 ## Criticism and Project Direction
 
 Contributors should be open to criticism. Sometimes a change you worked hard on may not be accepted in its current form. That is part of the development process.
 
 Likewise, reviewers and maintainers should give criticism in a way that helps the contributor understand the concern and improve the work.
+
+---
 
 ## Enforcement
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,63 @@
+# GTNH Code of Conduct
+
+## Scope
+
+This Code of Conduct applies to anyone representing or contributing to the GTNH project, including on GitHub, Discord, and any other GTNH-related space.
+
+## Expected Behavior
+
+GTNH developers and contributors are expected to treat others with respect.
+
+In short: **do not be a jerk.**
+
+This includes, but is not limited to:
+
+- Being respectful toward other developers, contributors, players, and community members.
+- Giving feedback constructively.
+- Disagreeing with ideas without insulting the person proposing them.
+- Assuming good faith when possible.
+- Being open to criticism and review.
+- Remembering that comments made on GitHub or Discord reflect on the GTNH project as a whole.
+
+Behind every pull request, issue, or review comment is a person who has invested time and effort into the project. A single rude or dismissive comment can discourage someone from contributing again. Today’s new contributor may become tomorrow’s project lead.
+
+## Unacceptable Behavior
+
+The following behavior is not acceptable:
+
+- Insulting, harassing, or belittling other developers, contributors, players, or community members.
+- Malicious trolling.
+- Looking down on others because they disagree with you, know less than you, or made a mistake.
+- Attacking people instead of discussing their ideas or changes.
+- Repeatedly creating hostile, dismissive, or unconstructive discussions.
+- Representing GTNH in a way that damages the project or discourages contribution.
+
+Disagreement is allowed. Strong technical opinions are allowed. Personal attacks are not.
+
+## Review Conduct
+
+When reviewing pull requests, keep feedback constructive, actionable, and respectful.
+
+Good review behavior includes:
+
+- Explaining what should change and why.
+- Asking questions when something is unclear.
+- Highlighting what was done well, not only what needs improvement.
+- Framing concerns as genuine discussion rather than personal criticism.
+- Helping contributors improve instead of discouraging them.
+
+If a pull request is unclear, incomplete, or incorrect, say so respectfully and explain what is needed.
+
+## Criticism and Project Direction
+
+Contributors should be open to criticism. Sometimes a change you worked hard on may not be accepted in its current form. That is part of the development process.
+
+Likewise, reviewers and maintainers should give criticism in a way that helps the contributor understand the concern and improve the work.
+
+## Enforcement
+
+Violations of this Code of Conduct may result in moderator or maintainer action.
+
+Depending on severity and history, this may include warnings, removal from a discussion, loss of developer permissions, or demotion from GTNH roles.
+
+Major contributions to the pack do not exempt anyone from following the Code of Conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,35 +2,36 @@
 
 These guidelines explain how to contribute to GTNH, what is expected in pull requests, and how content, balance, and reviews should be handled.
 
-For behavior expectations, see the project Code of Conduct.
+Before contributing, please read and follow the project [Code of Conduct](https://github.com/GTNewHorizons/.github/blob/main/CODE_OF_CONDUCT.md) and [AI Usage Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md). The AI policy applies to code, written content, issues, discussions, pull requests, and media.
 
-## Pull Request Descriptions
-
-Pull requests that add features, change features, or affect balance should clearly explain:
-
-- What the PR changes.
-- Why the change is being made.
-- What area of the pack it affects.
-- Any context reviewers need to understand the change.
-- Any Discord discussion or prior agreement relevant to the PR.
-
-The more precise the description, the easier the PR is to review.
-
-Additional expectations:
-
-- Screenshots and videos are strongly encouraged when they help explain the change.
-- Screenshots/videos may also be useful for changelogs or `#upcoming-features`.
-- PR titles should be written as if they may appear in a changelog.
-- Prefer multiple clear, focused commits over one large commit.
-- Commit names should reflect the changes they contain.
-
-## Content Creation Guidelines
+## 1. General Contribution Expectations
 
 ### Know the Area You Are Changing
 
 - Avoid changing areas of the pack you have never personally reached as a player.
 - If you have not reached that area, get feedback from developers or players who are experienced with it.
 - This is especially important for balance, progression, and late-game systems.
+
+---
+
+### Discuss Major New Content First
+
+- Do not open PRs with major new content unless the idea has been discussed with the team first.
+- The team should understand the intended design before implementation.
+- Avoid changes where only the PR author fully understands what is being added.
+- Significant content should not be discovered by the rest of the team only after it ships.
+
+---
+
+### Respect the Vision
+
+- Respect the GTNH vision.
+- If an idea is not covered by the vision document:
+  - Discuss it in `#meta-dev`.
+  - If there is agreement, the vision document can be updated.
+  - Then implementation can proceed.
+
+---
 
 ### New Content Below IV
 
@@ -42,20 +43,7 @@ Additional expectations:
   - Wait for general consensus before starting serious work.
   - Do not spend major development time on something likely to be rejected.
 
-### Discuss New Content First
-
-- Do not open PRs with major new content unless the idea has been discussed with the team first.
-- The team should understand the intended design before implementation.
-- Avoid changes where only the PR author fully understands what is being added.
-- Significant content should not be discovered by the rest of the team only after it ships.
-
-### Respect the Vision
-
-- Respect the GTNH vision.
-- If an idea is not covered by the vision document:
-  - Discuss it in `#meta-dev`.
-  - If there is agreement, the vision document can be updated.
-  - Then implementation can proceed.
+---
 
 ### Be Open to Criticism
 
@@ -63,81 +51,111 @@ Additional expectations:
 - Content you are proud of may not be accepted in its current form.
 - Criticism of a change is not criticism of the person who made it.
 
+---
+
+## 2. Pull Request Requirements
+
+### PR Descriptions
+
+Pull requests that add features, change features, or affect balance should clearly explain:
+
+- What the PR changes.
+- Why the change is being made.
+- What area of the pack it affects.
+- Any context reviewers need to understand the change.
+- Any Discord discussion or prior agreement relevant to the PR.
+
+The more precise the description, the easier the PR is to review.
+
+---
+
+### PR Titles and Changelog Context
+
+- PR titles should be written as if they may appear in a changelog.
+- Context is important because changelog entries may be generated from PR titles.
+
+---
+
+### Screenshots, Videos, and Examples
+
+- Screenshots and videos are strongly encouraged when they help explain the change.
+- Screenshots and videos may also be useful for changelogs or `#upcoming-features`.
+
+---
+
+### Commits
+
+- Prefer multiple clear, focused commits over one large commit.
+- Commit names should reflect the changes they contain.
+
+---
+
+### PR Template Requirement
+
+- The PR template must be properly filled out.
+- If there are any details that need to be included such as other PRs required for merge or to what degree AI was used in the PR please mention it under the respective bullet point.
+
+---
+
 ### Recipe Chains Require Flowcharts
 
 - Any PR that adds a new recipe chain must include a flowchart.
 - Recipe-chain PRs without a flowchart may be rejected regardless of quality.
 - If you do not know how to make one, try [draw.io](https://draw.io).
 
-## Texture and GUI Guidelines
+---
 
-### New Textures
+## 3. Special Rules for Balance Changes
 
-- New textures should generally remain consistent with the mod or mod group they are being added to. Ideally they should all be ran past an admin before being merged.
+Balance-affecting PRs must follow the GTNH vision.
 
-### Magic Textures
+### Label Requirement
 
-- Magic is meant to feel, look, and play differently from GregTech.
-- Do not update magic GUIs purely for consistency with GregTech if it damages the distinct feel of magic content.
-- Magic content should preserve its own artistic and mechanical identity.
+- Use the `Affects Balance` label when appropriate.
+- Do not mix balance changes with unrelated changes in the same PR.
 
-### Tooltips
+---
 
-- Tooltip reduction is fine when needed.
-- If a mod or system has a specific tooltip style or consistency, try to preserve it.
+### Approval Requirement
 
-### Inventory Color Changes
+- At least two approvals are required.
+- One approval must be from a member of the admin team.
 
-GUIs that shift the color of the player’s inventory are allowed if the usage is consistent.
+---
 
-Examples include:
+### Required Balance PR Questions
 
-- GT Steam Machines
-- Magic Bees’ Magic Apiary
-- Railcraft’s Coke Oven
+When a PR is tagged as balance-affecting, the author must answer the following questions:
 
-## Magic Design Guidelines
+1. What goal is this change trying to achieve? What tier is it targeting?
+2. What side effects does this have on other lines or systems? How does it change the game meta?
+3. If relevant, do you have metrics, a spreadsheet, or a visualization explaining the change? If it is a new multiblock, can you provide a picture and/or practical setup?
+4. Is this change being made in expectation of, or in tandem with, another unwritten or unmerged change coming later?
 
-Magic in GTNH is intended to have a strong and distinct look, feel, and execution compared to the technology-focused parts of the pack.
+Notes:
 
-When designing or balancing magic content:
+- These questions help clarify the author’s reasoning.
+- They make discussion easier.
+- They preserve context that may otherwise be lost in Discord.
+- Authors do not need perfect answers to every question, but an attempt should be made.
+- A balance PR that does not answer these questions may be rejected regardless of quality.
 
-- Respect the artistic identity of each magic mod.
-- Respect the mechanical identity of each magic mod.
-- Consider lore, theme, and progression.
-- Avoid forcing magic content to behave like tech content unless there is a strong design reason.
+---
 
-### Thaumcraft
+## 4. Content and Design Standards
 
-Thaumcraft is a lore mod. While it is a magic mod, it is also trying to tell a distinct story with specific limitations and paths.
+### General Content Expectations
 
-When working on Thaumcraft content:
+When adding or changing pack content:
 
-- Take Thaumcraft lore seriously.
-- Do not freely violate Thaumcraft’s internal logic.
-- Essentia types should not be allowed to mix freely if doing so would violate canon.
-- A single jar should not store multiple essentia types.
-- A reservoir may be acceptable depending on implementation and lore.
-- Lore can be used creatively, such as for mechanisms that intentionally keep essentia separate until reaction.
-- Thaumcraft lives and dies on the quality of its lore.
-- Some data is acceptable, but hard numbers are generally better suited for the questbook than the Thaumonomicon.
-- Lore entries should be written seriously.
-- Joke entries are allowed for isolated items or chains.
-- Do not create an entire research tab for trivial jokes.
-- Intentionally misleading data is forbidden.
-- Do not include joke text suggesting extreme warp values in a research entry that actually contains warp.
-- Do not add content directly to vanilla Thaumcraft tabs.
-  - This is a direct request from Azanor in the Thaumcraft addon terms.
-  - It can also cause issues with unlocking Kami.
+- Respect the identity of the mod or system being changed.
+- Consider how the change affects progression, balance, lore, and player experience.
+- Avoid forcing consistency where inconsistency is intentional or part of the design identity.
+- Ask for feedback when unsure.
 
-### Witchery
+---
 
-- Do not add new Witchery content directly to Witchery.
-- If you want to add Witchery-related content, add it to Forbidden Magic instead.
-- Witchery exists as a singular ARR island compared to the broader addon ecosystems around other magic mods.
-- If you want to see new Witchery content, consider helping recreate vital portions in new, untethered code.
-
-## Language Standards in Pack Content and Code
+### Language Standards in Pack Content and Code
 
 Profanity and insults are not acceptable in the pack.
 
@@ -159,39 +177,52 @@ Rules:
 - If you edit existing content or code and find something that violates this standard, remove or replace it.
 - If you are unsure about a phrase, ask others for feedback.
 
-## Balance-Affecting Pull Requests
+---
 
-Balance-affecting PRs must follow the GTNH vision.
+### Texture and GUI Guidelines
 
-Rules for balance PRs:
+#### New Textures
 
-- Use the `Affects Balance` label when appropriate.
-- Do not mix balance changes with unrelated changes in the same PR.
-- For IV and below, follow the new-content guidelines above.
-- For LuV and above:
-  - At least two approvals are required.
-  - One approval must be from a member of the GitHub admin team.
-  - Admin team: https://github.com/orgs/GTNewHorizons/teams/admin
+- New textures should generally remain consistent with the mod or mod group they are being added to.
+- Ideally, new textures should be run past an admin before being merged.
 
-### Required Balance PR Questions
+#### Magic Textures
 
-When a PR is tagged as balance-affecting, the author must answer the following questions:
+- Magic is meant to feel, look, and play differently from GregTech.
+- Do not update magic GUIs purely for consistency with GregTech if it damages the distinct feel of magic content.
+- Magic content should preserve its own artistic and mechanical identity.
 
-1. What goal is this change trying to achieve? What tier is it targeting?
-2. What side effects does this have on other lines or systems? How does it change the game meta?
-3. If relevant, do you have metrics, a spreadsheet, or a visualization explaining the change? If it is a new multiblock, can you provide a picture and/or practical setup?
-4. Is this change being made in expectation of, or in tandem with, another unwritten or unmerged change coming later?
+#### Tooltips
 
-Notes:
+- Tooltip reduction is fine when needed.
+- If a mod or system has a specific tooltip style or consistency, try to preserve it.
 
-- These questions help clarify the author’s reasoning.
-- They make discussion easier.
-- They preserve context that may otherwise be lost in Discord.
-- Authors do not need perfect answers to every question, but an attempt should be made.
-- A balance PR that does not answer these questions may be rejected regardless of quality.
-- The requirement may be bypassed in reasonable scenarios, such as emergency reverts.
+#### Inventory Color Changes
 
-## Reviewing Pull Requests
+GUIs that shift the color of the player’s inventory are allowed if the usage is consistent.
+
+Examples include:
+
+- GT Steam Machines
+- Magic Bees’ Magic Apiary
+- Railcraft’s Coke Oven
+
+---
+
+### Magic Design Guidelines
+
+Magic in GTNH is intended to have a strong and distinct look, feel, and execution compared to the technology-focused parts of the pack.
+
+When designing or balancing magic content:
+
+- Respect the artistic identity of each magic mod.
+- Respect the mechanical identity of each magic mod.
+- Consider lore, theme, and progression.
+- Avoid forcing magic content to behave like tech content unless there is a strong design reason.
+
+---
+
+## 5. Reviewing Pull Requests
 
 These are general review guidelines. They do not need to be followed mechanically in every case, but they describe the expected review approach.
 
@@ -200,6 +231,8 @@ These are general review guidelines. They do not need to be followed mechanicall
 - Avoid approving balance-affecting PRs if you are not familiar with the implications of the proposed changes.
 - This is especially important for balance changes, because they can negatively affect the wider community if reviewed incorrectly.
 - You may still ask questions or point out possible issues, even if you are not comfortable approving the PR.
+
+---
 
 ### Know Your Limits and Expand Them
 
@@ -213,6 +246,8 @@ These are general review guidelines. They do not need to be followed mechanicall
 - Do not approve a PR unless you understand the change well enough to be confident in the approval.
 - As you become familiar with more systems, gradually increase the complexity of the PRs you review.
 
+---
+
 ### Ask When Something Is Unclear
 
 - If code or logic is only understood by the author, ask them to clarify it.
@@ -224,6 +259,8 @@ These are general review guidelines. They do not need to be followed mechanicall
 - This prevents knowledge gaps and helps future maintainers.
 - If a concept is difficult to explain even after discussion, the author should consider documenting it directly in the code.
 
+---
+
 ### Read the PR Description
 
 - The PR description gives reviewers a quick overview of the change.
@@ -232,6 +269,8 @@ These are general review guidelines. They do not need to be followed mechanicall
   - Understand the scope.
   - Decide whether they are the right person to review it.
   - Understand the intended purpose of the change.
+
+---
 
 ### Contribute Positively
 
@@ -245,16 +284,12 @@ Remember:
 - If something is unclear, frame the concern as a genuine question rather than an implied criticism.
 - A community thrives when contributors feel valued and respected.
 
-## Developer Breaks and Hiatus
+---
 
-Understanding the active developer count helps the team redistribute tasks more efficiently.
+## 6. Developer Breaks and Hiatus
 
-Guidelines:
+Life events may require developers to temporarily step back from GTNH.
 
-- Life events may require developers to temporarily step back from GTNH.
-- If you expect to take a break, consider setting your status to inactive.
-- This helps others know not to approach you for GTNH-related work.
-- Inactive status is not a demotion.
-- You can request to be reactivated after your break.
-- Sometimes breaks happen unexpectedly.
+- If you expect to take a break, consider setting your status to inactive. This helps others know not to approach you for GTNH-related work.
+- Inactive status is not a demotion, you can request to be reactivated after your break.
 - After a month of inactivity, defined as no code contributions or PR reviewing, a developer may be marked as on hiatus.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,260 @@
+# GTNH Contribution Guidelines
+
+These guidelines explain how to contribute to GTNH, what is expected in pull requests, and how content, balance, and reviews should be handled.
+
+For behavior expectations, see the project Code of Conduct.
+
+## Pull Request Descriptions
+
+Pull requests that add features, change features, or affect balance should clearly explain:
+
+- What the PR changes.
+- Why the change is being made.
+- What area of the pack it affects.
+- Any context reviewers need to understand the change.
+- Any Discord discussion or prior agreement relevant to the PR.
+
+The more precise the description, the easier the PR is to review.
+
+Additional expectations:
+
+- Screenshots and videos are strongly encouraged when they help explain the change.
+- Screenshots/videos may also be useful for changelogs or `#upcoming-features`.
+- PR titles should be written as if they may appear in a changelog.
+- Prefer multiple clear, focused commits over one large commit.
+- Commit names should reflect the changes they contain.
+
+## Content Creation Guidelines
+
+### Know the Area You Are Changing
+
+- Avoid changing areas of the pack you have never personally reached as a player.
+- If you have not reached that area, get feedback from developers or players who are experienced with it.
+- This is especially important for balance, progression, and late-game systems.
+
+### New Content Below IV
+
+- Avoid adding new content below IV tier.
+- The game is already dense, especially with chemical lines.
+- Bug fixes and quality-of-life changes are always appreciated.
+- If you have a strong reason to add new content below IV:
+  - Discuss it in `#meta-dev` first.
+  - Wait for general consensus before starting serious work.
+  - Do not spend major development time on something likely to be rejected.
+
+### Discuss New Content First
+
+- Do not open PRs with major new content unless the idea has been discussed with the team first.
+- The team should understand the intended design before implementation.
+- Avoid changes where only the PR author fully understands what is being added.
+- Significant content should not be discovered by the rest of the team only after it ships.
+
+### Respect the Vision
+
+- Respect the GTNH vision.
+- If an idea is not covered by the vision document:
+  - Discuss it in `#meta-dev`.
+  - If there is agreement, the vision document can be updated.
+  - Then implementation can proceed.
+
+### Be Open to Criticism
+
+- Feedback, revision, and rejection are normal parts of development.
+- Content you are proud of may not be accepted in its current form.
+- Criticism of a change is not criticism of the person who made it.
+
+### Recipe Chains Require Flowcharts
+
+- Any PR that adds a new recipe chain must include a flowchart.
+- Recipe-chain PRs without a flowchart may be rejected regardless of quality.
+- If you do not know how to make one, try [draw.io](https://draw.io).
+
+## Texture and GUI Guidelines
+
+### New Textures
+
+- New textures should generally remain consistent with the mod or mod group they are being added to. Ideally they should all be ran past an admin before being merged.
+
+### Magic Textures
+
+- Magic is meant to feel, look, and play differently from GregTech.
+- Do not update magic GUIs purely for consistency with GregTech if it damages the distinct feel of magic content.
+- Magic content should preserve its own artistic and mechanical identity.
+
+### Tooltips
+
+- Tooltip reduction is fine when needed.
+- If a mod or system has a specific tooltip style or consistency, try to preserve it.
+
+### Inventory Color Changes
+
+GUIs that shift the color of the player’s inventory are allowed if the usage is consistent.
+
+Examples include:
+
+- GT Steam Machines
+- Magic Bees’ Magic Apiary
+- Railcraft’s Coke Oven
+
+## Magic Design Guidelines
+
+Magic in GTNH is intended to have a strong and distinct look, feel, and execution compared to the technology-focused parts of the pack.
+
+When designing or balancing magic content:
+
+- Respect the artistic identity of each magic mod.
+- Respect the mechanical identity of each magic mod.
+- Consider lore, theme, and progression.
+- Avoid forcing magic content to behave like tech content unless there is a strong design reason.
+
+### Thaumcraft
+
+Thaumcraft is a lore mod. While it is a magic mod, it is also trying to tell a distinct story with specific limitations and paths.
+
+When working on Thaumcraft content:
+
+- Take Thaumcraft lore seriously.
+- Do not freely violate Thaumcraft’s internal logic.
+- Essentia types should not be allowed to mix freely if doing so would violate canon.
+- A single jar should not store multiple essentia types.
+- A reservoir may be acceptable depending on implementation and lore.
+- Lore can be used creatively, such as for mechanisms that intentionally keep essentia separate until reaction.
+- Thaumcraft lives and dies on the quality of its lore.
+- Some data is acceptable, but hard numbers are generally better suited for the questbook than the Thaumonomicon.
+- Lore entries should be written seriously.
+- Joke entries are allowed for isolated items or chains.
+- Do not create an entire research tab for trivial jokes.
+- Intentionally misleading data is forbidden.
+- Do not include joke text suggesting extreme warp values in a research entry that actually contains warp.
+- Do not add content directly to vanilla Thaumcraft tabs.
+  - This is a direct request from Azanor in the Thaumcraft addon terms.
+  - It can also cause issues with unlocking Kami.
+
+### Witchery
+
+- Do not add new Witchery content directly to Witchery.
+- If you want to add Witchery-related content, add it to Forbidden Magic instead.
+- Witchery exists as a singular ARR island compared to the broader addon ecosystems around other magic mods.
+- If you want to see new Witchery content, consider helping recreate vital portions in new, untethered code.
+
+## Language Standards in Pack Content and Code
+
+Profanity and insults are not acceptable in the pack.
+
+This applies to:
+
+- Quest text
+- Tooltips
+- In-game content
+- Code
+- Comments
+- Other user-facing or contributor-facing text
+
+Rules:
+
+- Do not use swearwords, even partially or fully censored.
+- If something is meant to be funny or witty, find another way to write it.
+- Do not insult the player or a group of players.
+- Light teasing may be acceptable only if you can be completely sure it will be understood as a joke.
+- If you edit existing content or code and find something that violates this standard, remove or replace it.
+- If you are unsure about a phrase, ask others for feedback.
+
+## Balance-Affecting Pull Requests
+
+Balance-affecting PRs must follow the GTNH vision.
+
+Rules for balance PRs:
+
+- Use the `Affects Balance` label when appropriate.
+- Do not mix balance changes with unrelated changes in the same PR.
+- For IV and below, follow the new-content guidelines above.
+- For LuV and above:
+  - At least two approvals are required.
+  - One approval must be from a member of the GitHub admin team.
+  - Admin team: https://github.com/orgs/GTNewHorizons/teams/admin
+
+### Required Balance PR Questions
+
+When a PR is tagged as balance-affecting, the author must answer the following questions:
+
+1. What goal is this change trying to achieve? What tier is it targeting?
+2. What side effects does this have on other lines or systems? How does it change the game meta?
+3. If relevant, do you have metrics, a spreadsheet, or a visualization explaining the change? If it is a new multiblock, can you provide a picture and/or practical setup?
+4. Is this change being made in expectation of, or in tandem with, another unwritten or unmerged change coming later?
+
+Notes:
+
+- These questions help clarify the author’s reasoning.
+- They make discussion easier.
+- They preserve context that may otherwise be lost in Discord.
+- Authors do not need perfect answers to every question, but an attempt should be made.
+- A balance PR that does not answer these questions may be rejected regardless of quality.
+- The requirement may be bypassed in reasonable scenarios, such as emergency reverts.
+
+## Reviewing Pull Requests
+
+These are general review guidelines. They do not need to be followed mechanically in every case, but they describe the expected review approach.
+
+### Review Within Your Knowledge
+
+- Avoid approving balance-affecting PRs if you are not familiar with the implications of the proposed changes.
+- This is especially important for balance changes, because they can negatively affect the wider community if reviewed incorrectly.
+- You may still ask questions or point out possible issues, even if you are not comfortable approving the PR.
+
+### Know Your Limits and Expand Them
+
+- Everyone has limits to what they know.
+- There is no limit to what they can learn.
+- If a PR is in an unfamiliar area:
+  - Read it.
+  - Ask questions.
+  - Identify possible issues.
+  - Point out inconsistencies or “code smells.”
+- Do not approve a PR unless you understand the change well enough to be confident in the approval.
+- As you become familiar with more systems, gradually increase the complexity of the PRs you review.
+
+### Ask When Something Is Unclear
+
+- If code or logic is only understood by the author, ask them to clarify it.
+- Clarification can happen in:
+  - A PR comment
+  - The PR description
+  - Documentation
+  - Code comments
+- This prevents knowledge gaps and helps future maintainers.
+- If a concept is difficult to explain even after discussion, the author should consider documenting it directly in the code.
+
+### Read the PR Description
+
+- The PR description gives reviewers a quick overview of the change.
+- If the description is empty or unclear, ask the author to complete it.
+- A good description helps reviewers:
+  - Understand the scope.
+  - Decide whether they are the right person to review it.
+  - Understand the intended purpose of the change.
+
+### Contribute Positively
+
+Review comments should be constructive, actionable, and respectful.
+
+Remember:
+
+- Behind every PR is a person who spent time and effort making a contribution.
+- Rude or dismissive reviews can discourage future contribution.
+- Highlight what is done well, not only what needs improvement.
+- If something is unclear, frame the concern as a genuine question rather than an implied criticism.
+- A community thrives when contributors feel valued and respected.
+
+## Developer Breaks and Hiatus
+
+Understanding the active developer count helps the team redistribute tasks more efficiently.
+
+Guidelines:
+
+- Life events may require developers to temporarily step back from GTNH.
+- If you expect to take a break, consider setting your status to inactive.
+- This helps others know not to approach you for GTNH-related work.
+- Inactive status is not a demotion.
+- You can request to be reactivated after your break.
+- Sometimes breaks happen unexpectedly.
+- After a month of inactivity, defined as no code contributions or PR reviewing, a developer may be marked as on hiatus.

--- a/profile/README.md
+++ b/profile/README.md
@@ -25,13 +25,15 @@
     </td>
     <td valign="top">
       <a href="https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/new/choose">🐞 Open a new issue</a><br>
+      <a href="https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues">🧹 View all open issues</a><br>
       <a href="https://github.com/pulls?q=is%3Aopen+is%3Apr+org%3AGTNewHorizons+archived%3Afalse+draft%3Afalse">🛠️ View all open pull requests</a><br>
       <a href="https://wiki.gtnewhorizons.com/wiki/Development">📕 Development wiki page</a><br>
       <a href="https://github.com/GTNewHorizons/DreamAssemblerXXL/actions/workflows/daily-modpack-build.yml">☀️ Daily builds</a><br>
       <a href="https://github.com/GTNewHorizons/DreamAssemblerXXL/actions/workflows/experimental-modpack-build.yml">🧪 Experimental builds</a><br>
       <a href="https://github.com/GTNewHorizons/ExampleMod1.7.10/releases/latest">📦 ExampleMod starter/migration package</a><br>
       <a href="https://nexus.gtnewhorizons.com/service/rest/repository/browse/public/">🪶 Maven</a><br>
-      <a href="https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/developer's%20code%20of%20conduct.md">📜 Developer's Code of Conduct</a><br>
+      <a href="https://github.com/GTNewHorizons/.github/blob/main/CODE_OF_CONDUCT.md">📜 Developer's Code of Conduct</a><br>
+      <a href="https://github.com/GTNewHorizons/.github/blob/main/CODE_OF_CONDUCT.md">📖 Contribution Guidelines</a><br>
     </td>
   </tr>
 </table>

--- a/profile/README.md
+++ b/profile/README.md
@@ -33,7 +33,7 @@
       <a href="https://github.com/GTNewHorizons/ExampleMod1.7.10/releases/latest">📦 ExampleMod starter/migration package</a><br>
       <a href="https://nexus.gtnewhorizons.com/service/rest/repository/browse/public/">🪶 Maven</a><br>
       <a href="https://github.com/GTNewHorizons/.github/blob/master/CODE_OF_CONDUCT.md">📜 Developer's Code of Conduct</a><br>
-      <a href="https://github.com/GTNewHorizons/.github/blob/master/CODE_OF_CONDUCT.md">📖 Contribution Guidelines</a><br>
+      <a href="https://github.com/GTNewHorizons/.github/blob/master/CONTRIBUTING.md">📖 Contribution Guidelines</a><br>
     </td>
   </tr>
 </table>

--- a/profile/README.md
+++ b/profile/README.md
@@ -32,8 +32,8 @@
       <a href="https://github.com/GTNewHorizons/DreamAssemblerXXL/actions/workflows/experimental-modpack-build.yml">🧪 Experimental builds</a><br>
       <a href="https://github.com/GTNewHorizons/ExampleMod1.7.10/releases/latest">📦 ExampleMod starter/migration package</a><br>
       <a href="https://nexus.gtnewhorizons.com/service/rest/repository/browse/public/">🪶 Maven</a><br>
-      <a href="https://github.com/GTNewHorizons/.github/blob/main/CODE_OF_CONDUCT.md">📜 Developer's Code of Conduct</a><br>
-      <a href="https://github.com/GTNewHorizons/.github/blob/main/CODE_OF_CONDUCT.md">📖 Contribution Guidelines</a><br>
+      <a href="https://github.com/GTNewHorizons/.github/blob/master/CODE_OF_CONDUCT.md">📜 Developer's Code of Conduct</a><br>
+      <a href="https://github.com/GTNewHorizons/.github/blob/master/CODE_OF_CONDUCT.md">📖 Contribution Guidelines</a><br>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This is basically a split of copy of the GTNH dev docs document, however when it's split and put into this repo it will show up under each repository like shown below (unless that repo has their own contributing or conduct document, then that will take precedence).

<img width="461" height="85" alt="image" src="https://github.com/user-attachments/assets/505555fb-5e1f-4b78-a417-6602fd5c03fe" />


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
